### PR TITLE
Make ignoring branches work from child directories

### DIFF
--- a/.smart-commit-ignore
+++ b/.smart-commit-ignore
@@ -1,0 +1,4 @@
+hotfix
+sprint-11
+new-feature
+user-story-5

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ $ commit "New feature"
 git commit -m "New feature"
 ```
 
-You can create a `.ignore` file in your directory to add custom branches you want to ignore. A `.ignore` file looks like [this](https://github.com/sbimochan/smart-commit/blob/master/.ignore).
+## Skip Branches
+
+To add a custom branch that you would like to skip, create a `.smart-commit-ignore` file in your top level directory. A `.smart-commit-ignore` file looks like [this](https://github.com/sbimochan/smart-commit/blob/master/.smart-commit-ignore).
+
+Also, you might want to add `.smart-commit-ignore` to your `.gitignore` file.
 
 ## License
 

--- a/commit
+++ b/commit
@@ -2,15 +2,19 @@
 
 echo 'Running commit script'
 
-IGNORED_BRANCHES=("dev" "master" "qa" "uat" "staging")	
-IGNORED_PATH="./.ignore"
+IGNORED_BRANCHES=("dev" "master" "qa" "uat" "staging")
+
+ROOT_DIRECTORY_CMD="git rev-parse --show-toplevel"
+GIT_ROOT_DIRECTORY=$(eval $ROOT_DIRECTORY_CMD)
+
+CUSTOM_IGNORED_PATH="$GIT_ROOT_DIRECTORY/.smart-commit-ignore"
 
 if [ -f "$IGNORED_PATH" ]
 then
     CUSTOM_BRANCHES=$(cat "$IGNORED_PATH")
-    BRANCHES=( $CUSTOM_BRANCHES )
-    IGNORED_BRANCHES=( ${IGNORED_BRANCHES[@]} ${BRANCHES[@]} )
-fi	
+    BRANCHES=($CUSTOM_BRANCHES)
+    IGNORED_BRANCHES=(${IGNORED_BRANCHES[@]} ${BRANCHES[@]})
+fi
 
 CURRENT_BRANCH_CMD="git rev-parse --abbrev-ref HEAD"
 CURRENT_BRANCH=$(eval $CURRENT_BRANCH_CMD)
@@ -19,7 +23,7 @@ COMMIT_WITH_BRANCH="git commit -m \"$CURRENT_BRANCH: $1\""
 DEFAULT_COMMIT="git commit -m \"$1\""
 
 IS_IGNORED=false
-	
+
 for branch in "${IGNORED_BRANCHES[@]}";
     do
         if [ "$CURRENT_BRANCH" == $branch ]
@@ -34,6 +38,5 @@ then
     echo "Commiting with branch name -> $CURRENT_BRANCH"
     eval $COMMIT_WITH_BRANCH
 else
-    echo "Commiting with default branch"
     eval $DEFAULT_COMMIT
 fi


### PR DESCRIPTION
* Rename `.ignore` to `.smart-commit-ignore` as `.ignore` could be anything
* Get the top level `.git` directory and find `.smart-commit-ignore` if any
* Remove messages that are not required