### PR TITLE
Add main in default ignored branch

### DIFF
--- a/commit
+++ b/commit
@@ -12,7 +12,7 @@ fi
 
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD)"
 GIT_ROOT_DIRECTORY=$(git rev-parse --show-toplevel)
-IGNORED_BRANCHES=("dev" "master" "qa" "uat" "staging")
+IGNORED_BRANCHES=("dev" "master" "main" "qa" "uat" "staging")
 CUSTOM_IGNORED_PATH="$GIT_ROOT_DIRECTORY/.smart-commit-ignore"
 
 if [ -f "$CUSTOM_IGNORED_PATH" ]; then


### PR DESCRIPTION
As Github and other platforms are now creating main as default branch, instead of master. And some existing repos are also, changing branch name from master to main. Adding "main" to default ignored branch for smart commit prefix of branch name.

https://github.com/github/renaming